### PR TITLE
[fix] fix Bizyair in onebrain codeserver can't set api key

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -56,7 +56,7 @@ set_api_key_html = """
             if(endpoint.includes('/bizyair/set-api-key'))
                endpoint = endpoint.replace('/bizyair/set-api-key','/bizyair/set_api_key');
             else
-               endpoint=`${endpoint}/bizyair/set_api_key`;
+               endpoint =`${endpoint}/bizyair/set_api_key`;
             const response = await fetch(endpoint, {
                 method: 'POST',
                 headers: {

--- a/auth.py
+++ b/auth.py
@@ -52,7 +52,12 @@ set_api_key_html = """
     <script>
         async function setApiKey() {
             const apiKey = document.getElementById('apiKey').value;
-            const response = await fetch('/bizyair/set_api_key', {
+            let endpoint = location.href;
+            if(endpoint.includes('/bizyair/set-api-key'))
+               endpoint=endpoint.replace('/bizyair/set-api-key','/bizyair/set_api_key');
+            else
+               endpoint=`${endpoint}/bizyair/set_api_key`;
+            const response = await fetch(endpoint, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'

--- a/auth.py
+++ b/auth.py
@@ -54,7 +54,7 @@ set_api_key_html = """
             const apiKey = document.getElementById('apiKey').value;
             let endpoint = location.href;
             if(endpoint.includes('/bizyair/set-api-key'))
-               endpoint=endpoint.replace('/bizyair/set-api-key','/bizyair/set_api_key');
+               endpoint = endpoint.replace('/bizyair/set-api-key','/bizyair/set_api_key');
             else
                endpoint=`${endpoint}/bizyair/set_api_key`;
             const response = await fetch(endpoint, {


### PR DESCRIPTION
本PR解决了在不同环境下ComfyUI访问端点不一致的问题，主要针对以下场景：

1. 问题描述：
   - 在OneBrain平台的CodeServer中，通过代理转发访问ComfyUI时，fetch请求的endpoint不正确，导致报错。
   - 原因：使用相对路径（如`fetch('/xx/xx')`）时，实际访问地址为当前domain+pathname，忽略了代理转发的pathname。

2. 影响范围：
   - 本地环境、无代理转发或使用泛域名时不受影响。
   - 在OneBrain平台网页版VSCode中访问时出现问题。

3. 解决方案：
   - 增加了对请求endpoint的处理逻辑，确保在所有环境中都能正确构造访问地址。

4. 验证结果：
   - 本地无代理环境测试通过。
   - OneBrain平台环境测试通过。

此修复提高了系统在不同网络环境下的兼容性和稳定性。
