### PR TITLE
Modified llm

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -22,8 +22,8 @@ class SiliconCloudLLMAPI:
         "Qwen2 72B Instruct": "Qwen/Qwen2-72B-Instruct",
         "(Free)Qwen2 7B Instruct": "Qwen/Qwen2-7B-Instruct",
         "No LLM Enhancement": "Bypass",
-        "(Free)Qwen2.5-7b Instruct": "Qwen/Qwen2.5-7b-Instruct",
-        "Qwen2.5-72b Instruct": "Qwen/Qwen2.5-72b-Instruct"
+        "(Free)Qwen2.5-7b Instruct": "Qwen/Qwen2.5-7B-Instruct",
+        "Qwen2.5-72b Instruct": "Qwen/Qwen2.5-72B-Instruct"
     }
 
     @classmethod

--- a/llm.py
+++ b/llm.py
@@ -22,6 +22,8 @@ class SiliconCloudLLMAPI:
         "Qwen2 72B Instruct": "Qwen/Qwen2-72B-Instruct",
         "(Free)Qwen2 7B Instruct": "Qwen/Qwen2-7B-Instruct",
         "No LLM Enhancement": "Bypass",
+        "(Free)Qwen2.5-7b Instruct": "Qwen/Qwen2.5-7b-Instruct",
+        "(Free)Qwen2.5-72b Instruct": "Qwen/Qwen2.5-72b-Instruct"
     }
 
     @classmethod

--- a/llm.py
+++ b/llm.py
@@ -23,7 +23,7 @@ class SiliconCloudLLMAPI:
         "(Free)Qwen2 7B Instruct": "Qwen/Qwen2-7B-Instruct",
         "No LLM Enhancement": "Bypass",
         "(Free)Qwen2.5-7b Instruct": "Qwen/Qwen2.5-7b-Instruct",
-        "(Free)Qwen2.5-72b Instruct": "Qwen/Qwen2.5-72b-Instruct"
+        "Qwen2.5-72b Instruct": "Qwen/Qwen2.5-72b-Instruct"
     }
 
     @classmethod


### PR DESCRIPTION
This PR add more model options for BizyAirSiliconCloudLLMAPI nodes, qwen2.5-7b vs. 72b.
Among them,Qwen2.5-7B-Instruct is available to users for free
![ef3642afb61118bcf233917f8dc3857](https://github.com/user-attachments/assets/299b5cdc-5e43-4735-9ce4-8636fb2a7ed8)
![a36bc9a7ba1613832a987710a48647d](https://github.com/user-attachments/assets/18c0eee0-7de0-4fbb-9dee-8f0ab85ba696)

The following is a screenshot of the operation:
![e5390ad40c89443e73b94ee2eaae527](https://github.com/user-attachments/assets/b4ac6720-a460-44cb-b801-1ea3358da0cb)
![e10f3b194806b8b951803e835f95af7](https://github.com/user-attachments/assets/284f0346-d4a7-4c46-9376-b6e0d867f53b)