### PR TITLE
Fix flux lora issue in path_manager.py

### DIFF
--- a/src/bizyair/path_utils/path_manager.py
+++ b/src/bizyair/path_utils/path_manager.py
@@ -53,7 +53,13 @@ def guess_url_from_node(
                         configs = routing_configs[config_key]
                         # TODO fix
                         if config_key == "flux-dev":
-                            if node["inputs"]["weight_dtype"] == "fp8_e4m3fn":
+                            if (
+                                node["inputs"]["weight_dtype"] == "fp8_e4m3fn"
+                                or node_usage_state.loras
+                            ):
+                                node["inputs"][
+                                    "weight_dtype"
+                                ] = "fp8_e4m3fn"  # set to fp8_e4m3fn for lora
                                 return (
                                     configs.get(
                                         "service_address", BIZYAIR_SERVER_ADDRESS


### PR DESCRIPTION
 只要有 lora，就往 flux + lora 的节点发送请求，避免如下错误
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/be33de7d-1482-4bf7-9239-ea4d823ed06c">
