### PR TITLE
feat: 优化一键登录体验

### DIFF
--- a/js/dialog/apiKey.js
+++ b/js/dialog/apiKey.js
@@ -65,25 +65,26 @@ export function apiKey() {
                 }),
                 $el('p.confirm-word', {}, [
                     'Please',
-                    $el('a.bizyair-link', {
-                        href: '',
-                        target: '_blank',
+                    $el('span.bizyair-link', {
                         onclick: () => {
                             openOAuthPopup((key) => {
                                 document.querySelector('#bizyair-api-key').value = key;
+                                requestAnimationFrame(() => {
+                                    toSubmit().then(removeDialog)
+                                });
                             });
                         }
                     }, ['click to login']),
-                    " and autofill the key,"
+                    "and autofill the key,"
                 ]),
-                $el('p.confirm-word', {}, ['or visit', $el('a.bizyair-link', { href: 'https://cloud.siliconflow.cn', target: '_blank' }, ['https://cloud.siliconflow.cn']), " to get your key and input manually."]),
+                $el('p.confirm-word', {}, ['or visit', $el('a.bizyair-link', { href: 'https://cloud.siliconflow.cn', target: '_blank' }, ['https://cloud.siliconflow.cn']), "to get your key and input manually."]),
                 $el('p.confirm-word', {}, [
                     "Setting the API Key signifies agreement to the",
                     $el('a.bizyair-link', {
                         href: 'https://docs.siliconflow.cn/docs/user-agreement',
                         target: '_blank'
                     }, ['User Agreement']),
-                    " and",
+                    "and",
                     $el('a.bizyair-link', {
                         href: 'https://docs.siliconflow.cn/docs/privacy-policy',
                         target: '_blank'
@@ -91,7 +92,7 @@ export function apiKey() {
                 ])
             ]
         );
-    dialog({
+    const removeDialog = dialog({
         title: 'Set API Key',
         content: content,
         yesText: 'Submit',

--- a/js/subassembly/dialog.js
+++ b/js/subassembly/dialog.js
@@ -37,7 +37,7 @@ export function dialog(params) {
         style: { zIndex: 10000 + document.querySelectorAll('.bizyair-new-dialog').length },
         onclick: function () {
             if (params.closeOnClickModal) {
-                removeDialog(this)
+                removeDialog()
             }
         },
     }, [
@@ -61,9 +61,9 @@ export function dialog(params) {
                                 return false
                             }
                         }
-                        removeDialog(document.getElementById(id))
+                        removeDialog()
                     }
-                }): ''),
+                }) : ''),
                 (params.neutralText ? $el("button.bizyair-new-dialog-btn", {
                     type: "button",
                     textContent: params.neutralText,
@@ -75,9 +75,9 @@ export function dialog(params) {
                                 return false
                             }
                         }
-                        removeDialog(document.getElementById(id))
+                        removeDialog()
                     }
-                }): ''),
+                }) : ''),
                 (params.noText ? $el("button.bizyair-new-dialog-btn", {
                     type: "button",
                     textContent: params.noText,
@@ -85,9 +85,9 @@ export function dialog(params) {
                         if (params.onNo) {
                             await params.onNo();
                         }
-                        removeDialog(document.getElementById(id))
+                        removeDialog()
                     }
-                }): '')
+                }) : '')
             ]),
         ])
     ]);
@@ -99,7 +99,7 @@ export function dialog(params) {
                 if (params.onNo) {
                     await params.onNo();
                 }
-                removeDialog(el);
+                removeDialog();
             }
         }
     };
@@ -109,7 +109,8 @@ export function dialog(params) {
         document.addEventListener("keydown", fnEscapeClose);
     }
 
-    function removeDialog(el) {
+    function removeDialog() {
+        const el = document.getElementById(id);
         requestAnimationFrame(() => {
             el.querySelector('.bizyair-dialog-content').style.transition = 'all 0.2s';
             el.querySelector('.bizyair-dialog-content').style.transform = 'translate(-50%, -50%) scale(0)';
@@ -122,6 +123,8 @@ export function dialog(params) {
         document.removeEventListener("keydown", fnEscapeClose);
         dialogStack = dialogStack.filter(d => d !== el);
     }
+
+    return removeDialog;
 }
 dialog.succeed = params => {
     if (typeof params === 'string') {

--- a/js/subassembly/styleUploadFile.js
+++ b/js/subassembly/styleUploadFile.js
@@ -216,6 +216,9 @@ input.cm-input-item-error{
 .bizyair-link{
     color: var(--bizyair-link);
     margin-left: 10px;
+    margin-right: 10px;
+    cursor: pointer;
+    text-decoration: underline;
 }
 .bizyair-model-list{
     width: 1000px;


### PR DESCRIPTION
原始登录链接使用空的 a 标签，点一键登录会打开一个新的标签页。调整为 span 标签，只处理 onclick 事件。并修改样式，与 a 标签保持统一。

另外新增一键登录之后自动关闭弹框。