### PR TITLE
feat: Load Image(URL) 节点 扩展支持 base64 方式

### DIFF
--- a/bizyair_extras/nodes_image_utils.py
+++ b/bizyair_extras/nodes_image_utils.py
@@ -1,8 +1,8 @@
-import os
-import urllib.request
 import base64
-import time
+import os
 import re
+import time
+import urllib.request
 
 import folder_paths
 
@@ -35,11 +35,11 @@ class LoadImageURL(BizyAirBaseNode):
     def apply(self, url: str):
         url = url.strip()
         input_dir = folder_paths.get_input_directory()
-        
+
         # check if it's a base64 encoded image
-        base64_pattern = r'^data:image/([a-zA-Z]+);base64,'
+        base64_pattern = r"^data:image/([a-zA-Z]+);base64,"
         match = re.match(base64_pattern, url)
-        
+
         if match:
             # get image format
             image_format = match.group(1)
@@ -47,10 +47,10 @@ class LoadImageURL(BizyAirBaseNode):
             timestamp = int(time.time() * 1000)  # precise to milliseconds
             filename = f"base64-{timestamp}.{image_format}"
             file_path = os.path.join(input_dir, filename)
-            
+
             # decode base64 data and save file
-            image_data = url.split(',')[1]
-            with open(file_path, 'wb') as f:
+            image_data = url.split(",")[1]
+            with open(file_path, "wb") as f:
                 f.write(base64.b64decode(image_data))
             print(f"Base64 image saved as {filename}")
         else:
@@ -64,7 +64,7 @@ class LoadImageURL(BizyAirBaseNode):
                 # Download the image
                 urllib.request.urlretrieve(url, file_path)
                 print(f"Image successfully downloaded and saved as {filename}.")
-        
+
         return LoadImage().load_image(filename)
 
 


### PR DESCRIPTION
base64 方式：
<img width="790" alt="image" src="https://github.com/user-attachments/assets/fee331f2-dffc-40d7-a6b9-27e3b8188dd9">

---

原始的两种方式未受影响：

<img width="782" alt="image" src="https://github.com/user-attachments/assets/50ac82cb-630e-4d98-8a33-488b6d784a8c">

<img width="776" alt="image" src="https://github.com/user-attachments/assets/b87a79f1-0909-44d8-b6e1-fa244d677438">
