### PR TITLE
add aliyun sdk requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ oss2
 crcmod
 requests
 aiofiles
+aliyun-python-sdk-core
+aliyun-python-sdk-kms


### PR DESCRIPTION
发现一个问题，可能长期部分用户反馈安装 models 依赖不成功有关：

首次安装 oss2 时，会自动安装 aliyun-python-sdk-core 和 aliyun-python-sdk-kms 两个 package。

但是，如果 oss2 已经安装成功，而另外2个包不存在时，oss2 并不会做相关检查和提示。
而我们的 requirements 中没这两个依赖，自动安装也无法解决 oss2 不能正常运行的问题。

不过暂时还是没有定位清楚，为什么部分 windows 下的用户，存在 oss 安装成功，但是 aliyun sdk 并不安装的问题。