### PR TITLE
improve: 优化 base64 image 加载时的文件命名方式

### DIFF
--- a/bizyair_extras/nodes_image_utils.py
+++ b/bizyair_extras/nodes_image_utils.py
@@ -1,7 +1,7 @@
 import base64
+import hashlib
 import os
 import re
-import time
 import urllib.request
 
 import folder_paths
@@ -43,25 +43,28 @@ class LoadImageURL(BizyAirBaseNode):
         if match:
             # get image format
             image_format = match.group(1)
-            # generate a file name with timestamp
-            timestamp = int(time.time() * 1000)  # precise to milliseconds
-            filename = f"base64-{timestamp}.{image_format}"
+            image_data = url.split(",")[1]
+
+            # calculate hash of the base64 data
+            hash_object = hashlib.md5(image_data.encode())
+            hash_value = hash_object.hexdigest()
+
+            filename = f"base64-{hash_value}.{image_format}"
             file_path = os.path.join(input_dir, filename)
 
-            # decode base64 data and save file
-            image_data = url.split(",")[1]
-            with open(file_path, "wb") as f:
-                f.write(base64.b64decode(image_data))
-            print(f"Base64 image saved as {filename}")
+            if not os.path.exists(file_path):
+                with open(file_path, "wb") as f:
+                    f.write(base64.b64decode(image_data))
+                print(f"Base64 image saved as {filename}")
+            else:
+                print(f"Base64 image {filename} already exists, skipping save.")
         else:
             filename = os.path.basename(url)
             file_path = os.path.join(input_dir, filename)
 
-            # Check if the file already exists
             if os.path.exists(file_path):
                 print(f"File {filename} already exists, skipping download.")
             else:
-                # Download the image
                 urllib.request.urlretrieve(url, file_path)
                 print(f"Image successfully downloaded and saved as {filename}.")
 


### PR DESCRIPTION
之前 Load Image 节点扩展支持 base64 图片加载的文件命名考虑欠妥，这里做一些修正：

1. 使用 md5 hash 代替 timestamp，避免重复写入相同的图片文件
2. 已存在相同 hash 的文件，则直接加载

*对于 base64 图片来说，hash 冲突导致相同 hash 的概率可忽略不计，可以放心使用*

---
写入文件的命名结果如图：

<img width="735" alt="Snipaste_2024-11-13_13-10-21" src="https://github.com/user-attachments/assets/559e76e6-0376-4583-bba4-dc3f4be039e9">
