### PR TITLE
add-super-resolution-model-temp

### DIFF
--- a/src/bizyair/configs/models.json
+++ b/src/bizyair/configs/models.json
@@ -84,6 +84,9 @@
   ],
   "upscale_models": [
     "4x_NMKD-Siax_200k.pth",
+    "RealESRGAN_x4plus.pth",
+    "RealESRGAN_x4plus_anime_6B.pth",
+    "RealESRGAN_x2plus.pth",
     "RealESRGAN_x4plus.pth"
   ],
   "instantid": [

--- a/src/bizyair/configs/models.json
+++ b/src/bizyair/configs/models.json
@@ -83,7 +83,8 @@
     "t5xxl_fp8_e4m3fn.safetensors"
   ],
   "upscale_models": [
-    "4x_NMKD-Siax_200k.pth"
+    "4x_NMKD-Siax_200k.pth",
+    "RealESRGAN_x4plus.pth"
   ],
   "instantid": [
     "ip-adapter.bin"


### PR DESCRIPTION
| 模型名| License  |上线状态|🔎详情| 
|---|---|---|---|
| RealESRGAN_x4plus.pth  |  BSD-3-Clause | ✅|<details close> <summary> https://openmodeldb.info/models/4x-realesrgan-x4plus </summary> <img width="1633" alt="image" src="https://github.com/user-attachments/assets/47e47c63-98b0-466e-bf1b-09509a6d6647" /> </details> | 
| RealESRGAN_x4plus_anime_6B.pth|BSD-3-Clause |✅|<details close> <summary> https://openmodeldb.info/models/4x-realesrgan-x4plus-anime-6b </summary><img width="1784" alt="image" src="https://github.com/user-attachments/assets/e84e91d9-30b7-48e3-bfed-cde6c2c0ed07" /></details> |
| 4x-UltraSharp.pth|CC-BY-NC-SA-4.0 | ❌ |<details close> <summary> https://openmodeldb.info/models/4x-UltraSharp </summary><img width="1745" alt="image" src="https://github.com/user-attachments/assets/06ae2e9f-68c7-48fd-a36f-926c862b04ef" /></details> |
| RealESRGAN_x2plus.pth|BSD-3-Clause |✅|<details close> <summary> https://openmodeldb.info/models/2x-realesrgan-x2plus </summary><img width="1798" alt="image" src="https://github.com/user-attachments/assets/b9b3ce8b-4f58-4d30-a588-efbe7126be31" /></details> |
| RealESRGAN_x4plus.pth|BSD-3-Clause |✅|<details close> <summary>https://openmodeldb.info/models/4x-realesrgan-x4plus </summary><img width="1793" alt="image" src="https://github.com/user-attachments/assets/2b8e95dd-b081-4820-8ee7-f5c548d7ba8d" /></details> |