### PR TITLE
Refactor API Key

### DIFF
--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -124,10 +124,11 @@ jobs:
       env:
         BIZYAIR_KEY: ${{ secrets.BIZYAIR_KEY }}
         BIZYAIR_API_KEY: ${{ secrets.BIZYAIR_KEY }}
-        BIZYAIR_SERVER_ADDRESS: ${{ vars.BIZYAIR_SERVER_ADDRESS }}
+        BIZYAIR_DOMAIN: ${{ vars.BIZYAIR_DOMAIN }}
         PYTHONPATH: ${{ github.workspace }}/ComfyUI
         BIZYAIR_TEST_SKIP_WORKFLOW_IDS: ${{ vars.BIZYAIR_TEST_SKIP_WORKFLOW_IDS }}
         BIZYAIR_OFFICIAL_WORKFLOW_MAX_TOTAL: ${{ vars.BIZYAIR_OFFICIAL_WORKFLOW_MAX_TOTAL }}
+        BIZYAIR_SKIP_UPDATE: ${{ vars.BIZYAIR_SKIP_UPDATE }}
 
     - name: Run ComfyUI on Windows
       if: matrix.os == 'windows-latest'
@@ -141,8 +142,9 @@ jobs:
       env:
         BIZYAIR_KEY: ${{ secrets.BIZYAIR_KEY }}
         BIZYAIR_API_KEY: ${{ secrets.BIZYAIR_KEY }}
-        BIZYAIR_SERVER_ADDRESS: ${{ vars.BIZYAIR_SERVER_ADDRESS }}
+        BIZYAIR_DOMAIN: ${{ vars.BIZYAIR_DOMAIN }}
         PYTHONPATH: ${{ github.workspace }}/ComfyUI
         PYTHONIOENCODING: utf-8
         BIZYAIR_TEST_SKIP_WORKFLOW_IDS: ${{ vars.BIZYAIR_TEST_SKIP_WORKFLOW_IDS }}
         BIZYAIR_OFFICIAL_WORKFLOW_MAX_TOTAL: ${{ vars.BIZYAIR_OFFICIAL_WORKFLOW_MAX_TOTAL }}
+        BIZYAIR_SKIP_UPDATE: ${{ vars.BIZYAIR_SKIP_UPDATE }}

--- a/.github/workflows/workflow-ci.yml
+++ b/.github/workflows/workflow-ci.yml
@@ -103,6 +103,14 @@ jobs:
         python3 -m pip install -r ComfyUI/custom_nodes/BizyAir/requirements.txt
         python3 -m pip show torch
 
+    - name: Install Local BizyAir
+      working-directory: ComfyUI/custom_nodes/BizyAir
+      run: |
+        cd backend
+        python3 -m pip install -e .
+        cd ../frontend
+        python3 -m pip install -e .
+
     - name: Run ComfyUI on Linux
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/backend/bizyengine/core/common/client.py
+++ b/backend/bizyengine/core/common/client.py
@@ -94,6 +94,7 @@ def get_api_key() -> str:
             if validate_api_key(BIZYAIR_API_KEY):
                 api_key_state.is_valid = True
                 api_key_state.current_api_key = BIZYAIR_API_KEY
+                print("API key set successfully")
     except Exception as e:
         print(str(e))
         raise ValueError(str(e))

--- a/backend/bizyengine/core/common/env_var.py
+++ b/backend/bizyengine/core/common/env_var.py
@@ -93,7 +93,7 @@ BIZYAIR_Y_SERVER = f"{_BIZYAIR_DOMAIN}/y/v1"
 
 BIZYAIR_SERVER_ADDRESS = ServerAddress(BIZYAIR_X_SERVER)
 
-# Initial value, DO NOT USE IN ACTUAL CODE!!!
+# Initial value, DO NOT CHANGE IN ACTUAL CODE!!!
 BIZYAIR_API_KEY = env("BIZYAIR_API_KEY", str, load_api_key()[1])
 # Development Settings
 BIZYAIR_DEV_REQUEST_URL = env("BIZYAIR_DEV_REQUEST_URL", str, None)

--- a/backend/bizyengine/core/common/env_var.py
+++ b/backend/bizyengine/core/common/env_var.py
@@ -83,9 +83,9 @@ def create_api_key_file(api_key):
 
 
 #   production:
-#     service_address: https://bizyair-api.siliconflow.cn/x/v1
+#     service_address: https://api.bizyair.cn/x/v1
 #   uat:
-#     service_address: https://uat-bizyair-api.siliconflow.cn/x/v1
+#     service_address: https://uat-api.bizyair.cn/x/v1
 _BIZYAIR_DOMAIN = os.getenv("BIZYAIR_DOMAIN", "https://api.bizyair.cn")
 BIZYAIR_DOMAIN = ServerAddress(_BIZYAIR_DOMAIN)
 BIZYAIR_X_SERVER = f"{_BIZYAIR_DOMAIN}/x/v1"

--- a/backend/bizyengine/core/common/env_var.py
+++ b/backend/bizyengine/core/common/env_var.py
@@ -59,7 +59,6 @@ def env(key, type_, default=None):
 
 
 def load_api_key():
-
     file_path = BIZYAIR_COMFYUI_PATH / "api_key.ini"
 
     if file_path.is_file() and file_path.exists():
@@ -94,6 +93,7 @@ BIZYAIR_Y_SERVER = f"{_BIZYAIR_DOMAIN}/y/v1"
 
 BIZYAIR_SERVER_ADDRESS = ServerAddress(BIZYAIR_X_SERVER)
 
+# Initial value, DO NOT USE IN ACTUAL CODE!!!
 BIZYAIR_API_KEY = env("BIZYAIR_API_KEY", str, load_api_key()[1])
 # Development Settings
 BIZYAIR_DEV_REQUEST_URL = env("BIZYAIR_DEV_REQUEST_URL", str, None)

--- a/backend/bizyengine/misc/auth.py
+++ b/backend/bizyengine/misc/auth.py
@@ -2,7 +2,6 @@ import os
 import uuid
 from pathlib import Path
 
-import bizyengine.core
 import bizyengine.core.common
 import server
 from aiohttp import web
@@ -23,7 +22,7 @@ async def set_api_key(request):
         data = await request.post()
         api_key = data.get("api_key")
         if api_key:
-            if not bizyengine.core.set_api_key(api_key, True):
+            if not bizyengine.core.common.set_api_key(api_key, True):
                 error_msg = "Wrong API key provided, please refer to cloud.siliconflow.cn to get the key"
                 print("set_api_key:", error_msg)
                 return web.Response(
@@ -48,7 +47,6 @@ async def set_api_key(request):
 async def get_api_key(request):
     try:
         if bizyengine.core.common.get_api_key():
-            print("test test test")
             return web.Response(text="Key has been loaded from the api_key.ini file")
         else:
             api_key = request.cookies.get("api_key")
@@ -58,7 +56,7 @@ async def get_api_key(request):
                     text="No api key found in cookies, please refer to cloud.siliconflow.cn to get the key",
                     status=404,
                 )
-            if bizyengine.core.set_api_key(api_key):
+            if bizyengine.core.common.set_api_key(api_key):
                 return web.Response(text="Key has been loaded from the cookies")
             return web.Response(text="Cannot set api key", status=500)
 

--- a/backend/bizyengine/misc/utils.py
+++ b/backend/bizyengine/misc/utils.py
@@ -123,9 +123,9 @@ def format_bytes(num_bytes: int) -> str:
 
 
 def get_api_key():
-    from .auth import API_KEY
+    from bizyengine.core.common import get_api_key as bcc_get_api_key
 
-    return API_KEY
+    return bcc_get_api_key()
 
 
 def get_llm_response(

--- a/tests/test_official_workflows.py
+++ b/tests/test_official_workflows.py
@@ -114,7 +114,7 @@ def clear_curernt_workflow(driver):
         raise Exception("Error: clear graph failed.")
 
 
-def wait_until_queue_finished(driver, timeout=100):
+def wait_until_queue_finished(driver, timeout=3600):
     time.sleep(0.3)
     try:
         wait = WebDriverWait(driver, timeout)
@@ -139,7 +139,7 @@ def wait_until_app_ready(driver):
     )
 
 
-def launch_and_wait(driver, *, timeout=100):
+def launch_and_wait(driver, *, timeout=3600):
     click_queue_prompt_button(driver)
     wait_until_queue_finished(driver, timeout)
 
@@ -361,7 +361,7 @@ if __name__ == "__main__":
             COMFY_HOST,
             COMFY_PORT,
             url,
-            timeout=100,
+            timeout=3600,
         )
 
     driver.quit()

--- a/tests/test_official_workflows.py
+++ b/tests/test_official_workflows.py
@@ -106,7 +106,7 @@ def click_queue_prompt_button(driver):
         raise Exception("Error: app.queuePrompt() failed.")
 
 
-def clear_curernt_workflow(driver):
+def clear_current_workflow(driver):
     try:
         driver.execute_script("window.app.graph.clear()")
     except Exception as e:
@@ -177,7 +177,7 @@ def launch_prompt(driver, comfy_host, comfy_port, workflow_url, timeout):
             app_ready = True
 
         print(" clear the workflow...")
-        clear_curernt_workflow(driver)
+        clear_current_workflow(driver)
         print(" workflow cleard")
 
         print(" load the target workflow...")


### PR DESCRIPTION
**改动：**
* 统一了三个来源的apikey相关代码
* 从全局环境变量改为使用api_key_state存储状态
* BIZYAIR_API_KEY作为session初值，来自环境变量或文件
* 设置key同时更新文件
* validate只检验不设置
* get返回api_key_state中当前key，如果尚未初始化，验证BIZYAIR_API_KEY后设置
* set验证后设置

**已本地测试：**
* 查看用户相关信息、模型广场、推理等功能
* 更换api key后功能依然正常

@doombeaker 先过ci再让更多人切这个分支试试看